### PR TITLE
Update Endpoint.js to support express route parameters with regex

### DIFF
--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -5,7 +5,7 @@ var Endpoint = function(endpoint) {
   this.attributes = endpoint
     .split('/')
     .filter(function(c) { return ~c.indexOf(':') && ~~c.indexOf(':unused'); })
-    .map(function(c) { return c.substring(1); });
+    .map(function(c) { return (c.indexOf('(') > -1 ? c.substring(1, c.indexOf('(')) : c.substring(1)); });
 };
 
 module.exports = Endpoint;


### PR DESCRIPTION
support http://expressjs.com/en/guide/routing.html#route-parameters with regex: "To have more control over the exact string that can be matched by a route parameter, you can append a regular expression in parentheses (())"

attribute for :id(\\d+) should just be id.