### PR TITLE
Utilize params rather than query

### DIFF
--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -137,7 +137,7 @@ List.prototype.fetch = function(req, res, context) {
   }
 
   // all other query parameters are passed to search
-  var extraSearchCriteria = _.reduce(req.query, function(result, value, key) {
+  var extraSearchCriteria = _.reduce(req.params, function(result, value, key) {
     if (_.has(model.rawAttributes, key)) result[key] = self._safeishParse(value, model.rawAttributes[key].type, Sequelize);
     return result;
   }, {});


### PR DESCRIPTION
Like the [read controller](https://github.com/tommybananas/finale/blob/0.1.3/lib/Controllers/read.js#L30-L33), `finale` needs to look at the request's params rather than the query directly.