### PR TITLE
Pass unknown errors to the next handler in Express/Restify

### DIFF
--- a/lib/Controllers/base.js
+++ b/lib/Controllers/base.js
@@ -73,12 +73,12 @@ Controller.prototype.route = function() {
   if (app.name === 'restify' && self.method === 'delete')
     self.method = 'del';
 
-  app[self.method](endpoint.string, function(req, res) {
-    self._control(req, res);
+  app[self.method](endpoint.string, function(req, res, next) {
+    self._control(req, res, next);
   });
 };
 
-Controller.prototype._control = function(req, res) {
+Controller.prototype._control = function(req, res, next) {
   var hookChain = Promise.resolve(false),
       self = this,
       context = {
@@ -191,6 +191,10 @@ Controller.prototype._control = function(req, res) {
     })
     .catch(function(err) {
       self.error(req, res, new errors.FinaleError(500, 'internal error', [err.message], err));
+
+      if (self.app.name !== 'restify') {
+        next(err);
+      }
     });
 };
 


### PR DESCRIPTION
This allows error handlers registered in the main app to process these errors.

Fixes #11