### PR TITLE
Updates package-lock.json to use the same info as package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "finale",
-  "version": "0.1.0",
+  "name": "finale-rest",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
I got these changes while running `npm install`. If you want contributors to use yarn, you should remove package-lock.json.