### PR TITLE
associations: subResourceName is set by association.as if available

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -68,7 +68,7 @@ var Resource = function(options) {
       this.attributes = getKeys(this.model.rawAttributes);
     }
   }
-  
+
   this.actions = options.actions;
   this.endpoints = {
     plural: options.endpoints[0],
@@ -226,21 +226,21 @@ function autoAssociate(resource) {
 
     var subResourceName;
     if (association.associationType === 'HasOne') {
-      subResourceName =
+      subResourceName = association.as ||
         association.target.options.name.singular.toLowerCase();
       resource[subResourceName] = hasOneResource(Resource, resource, association);
     } else if (association.associationType === 'HasMany') {
-      subResourceName =
+      subResourceName = association.as ||
         association.target.options.name.plural.toLowerCase();
       resource[subResourceName] = hasManyResource(Resource, resource, association);
     } else if (association.associationType === 'BelongsTo') {
-      subResourceName =
+      subResourceName = association.as ||
         association.target.options.name.singular.toLowerCase();
       resource[subResourceName] = belongsToResource(Resource, resource, association);
     } else if (association.associationType === 'BelongsToMany') {
-     subResourceName =
-       association.target.options.name.plural.toLowerCase();
-     resource[subResourceName] = belongsToManyResource(Resource, resource, association);
+      subResourceName = association.as ||
+        association.target.options.name.plural.toLowerCase();
+      resource[subResourceName] = belongsToManyResource(Resource, resource, association);
     }
   });
 }

--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -4,8 +4,8 @@ var _ = require('lodash');
 
 module.exports = function(Resource, resource, association) {
   // access points
-  var subResourceName =
-    association.target.options.name.plural.toLowerCase();
+  var subResourceName = association.as ||
+      association.target.options.name.plural.toLowerCase();
 
   // Find reverse association
   var associationPaired;

--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -2,8 +2,8 @@
 
 module.exports = function(Resource, resource, association) {
   // access points
-  var subResourceName =
-    association.target.options.name.singular.toLowerCase();
+  var subResourceName = association.as ||
+      association.target.options.name.singular.toLowerCase();
 
   var associatedResource = new Resource({
     app: resource.app,

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -2,8 +2,8 @@
 
 module.exports = function(Resource, resource, association) {
   // access points
-  var subResourceName =
-    association.target.options.name.plural.toLowerCase();
+  var subResourceName = association.as ||
+      association.target.options.name.plural.toLowerCase();
 
   var associatedResource = new Resource({
     app: resource.app,

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -2,8 +2,8 @@
 
 module.exports = function(Resource, resource, association) {
   // access points
-  var subResourceName =
-    association.target.options.name.singular.toLowerCase();
+  var subResourceName = association.as ||
+      association.target.options.name.singular.toLowerCase();
 
   var associatedResource = new Resource({
     app: resource.app,

--- a/tests/associations/sub-resource-name.test.js
+++ b/tests/associations/sub-resource-name.test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var expect = require('chai').expect,
+    rest = require('../../lib'),
+    test = require('../support');
+
+describe('Associations(named sub-resources)', function() {
+  describe('without using "as" to name an association', function() {
+    it('should name the sub-resources according to the model name', function(done) {
+      var Person = test.db.define('person', { name: { type: test.Sequelize.STRING } }, { underscored: true }),
+          Course = test.db.define('course', { name: { type: test.Sequelize.STRING } }, { underscored: true });
+      Course.hasMany(Person);
+      Course.hasOne(Person);
+      rest.initialize({
+        app: test.app,
+        sequelize: test.Sequelize
+      });
+      var resource = rest.resource({model: Course,
+                                    endpoints: ['/courses', '/courses/:id'],
+                                    associations: true});
+      expect(resource).to.not.have.property('students');
+      expect(resource).to.not.have.property('teacher');
+      expect(resource).to.have.property('people');
+      expect(resource).to.have.property('person');
+      done();
+    });
+  });
+  describe('using "as" to name an association', function() {
+    it('should name the sub-resources using the name provided by "as"', function(done) {
+      var Person = test.db.define('person', { name: { type: test.Sequelize.STRING } }, { underscored: true }),
+          Course = test.db.define('course', { name: { type: test.Sequelize.STRING } }, { underscored: true });
+      Course.hasMany(Person, { as: 'students' });
+      Course.hasOne(Person, { as: 'teacher' });
+      rest.initialize({
+        app: test.app,
+        sequelize: test.Sequelize
+      });
+      var resource = rest.resource({model: Course,
+                                    endpoints: ['/courses', '/courses/:id'],
+                                    associations: true});
+      expect(resource).to.have.property('students');
+      expect(resource).to.have.property('teacher');
+      expect(resource).to.not.have.property('people');
+      expect(resource).to.not.have.property('person');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
I think it makes sense to be able to decide what the `subResourceName` of an association is.  For instance, imagine that I have:
```
var Person = sequelize.define('person', { name: { type: DataTypes.STRING } }),
    Course = sequelize.define('course', { name: { type: DataTypes.STRING } });
Course.hasMany(Person, {as: 'students'});
Course.hasOne(Person, { as: 'teacher' });
rest.resource({model: Course, 
    endpoints: ['/courses', '/courses/:id'], 
    associations: true});
```
Under the current logic, the association Resources are named according to the model name, inflected for the number of the association.  I think with my example here, we would get `/courses/:id/person` and `/courses/:id/people/`.  Intuitively, though, it seems like we have gone to the trouble of naming the association in the model, and so we should get routes like `/courses/:id/students/` and `/courses/:id/teacher`.

This patch checks the `association.as` field before setting the `subResourceName`.