### PR TITLE
Add transaction support to create, update, delete

### DIFF
--- a/lib/Controllers/create.js
+++ b/lib/Controllers/create.js
@@ -32,9 +32,13 @@ Create.prototype.write = function(req, res, context) {
     });
   }
 
-  return this.model
-    .create(context.attributes, {
-      include: this.include
+  return this.model.sequelize
+    .transaction(function(transaction) {
+      return self.model
+        .create(context.attributes, {
+          include: self.include,
+          transaction: transaction
+        });
     })
     .then(function(instance) {
       if (self.resource) {

--- a/lib/Controllers/delete.js
+++ b/lib/Controllers/delete.js
@@ -17,8 +17,13 @@ Delete.prototype.plurality = 'singular';
 Delete.prototype.fetch = ReadController.prototype.fetch;
 
 Delete.prototype.write = function(req, res, context) {
-  return context.instance
-    .destroy()
+  return this.model.sequelize
+    .transaction(function(transaction) {
+      return context.instance
+        .destroy({
+          transaction: transaction
+        });
+    })
     .then(function() {
       context.instance = {};
       return context.continue;

--- a/lib/Controllers/update.js
+++ b/lib/Controllers/update.js
@@ -54,8 +54,13 @@ Update.prototype.write = function(req, res, context) {
       return instance._changed.hasOwnProperty(attr);
     });
 
-  return instance
-    .save()
+  return this.model.sequelize
+    .transaction(function(transaction) {
+      return instance
+        .save({
+          transaction: transaction
+        });
+    })
     .then(function(instance) {
       if (reloadAfter) {
         var reloadOptions = {};


### PR DESCRIPTION
Adds transaction support to create, update, and delete. With this PR, `hooks` can optionally make use of the transaction. Any failure in the promise chain during the operation or hooks triggers a rollback.

Addresses https://github.com/tommybananas/finale/issues/16