### PR TITLE
Fix deprecated call to `Model.find`

### DIFF
--- a/lib/Controllers/read.js
+++ b/lib/Controllers/read.js
@@ -52,7 +52,7 @@ Read.prototype.fetch = function(req, res, context) {
   }
 
   return model
-    .find(options)
+    .findOne(options)
     .then(function(instance) {
       if (!instance) {
         throw new errors.NotFoundError();

--- a/tests/associations/belongs-to.test.js
+++ b/tests/associations/belongs-to.test.js
@@ -421,7 +421,7 @@ describe('Associations(BelongsTo)', function() {
         expectedId = person.id;
         return person.setHobbies([hobby0, hobby1]);
       }).then(function(hobbies) {
-        return test.models.Person.find({
+        return test.models.Person.findOne({
           where: { id: expectedId },
           include: [
             { model: test.models.Address, as: 'addy' },


### PR DESCRIPTION
I am receiving this message:

`Thu, 03 Jan 2019 19:18:51 GMT sequelize deprecated Model.find has been deprecated, please use Model.findOne instead at node_modules\sequelize\lib\model.js:4212:9`

I think this is fixed with a simple replacement.