### PR TITLE
Fix lodash version in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1217,9 +1217,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "longest": {
       "version": "1.0.1",


### PR DESCRIPTION
In #37 I noticed that the build fails because package-lock is outdated. This change fixes that.