### PR TITLE
Added %% around the searchstring for al string operators

### DIFF
--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -90,17 +90,19 @@ List.prototype.fetch = function(req, res, context) {
           }
         }
 
-        var item = {};
-        var query = {};
-        var searchString;
-        if (![Sequelize.Op.like, '$like', '$ilike', '$iLike', '$notLike', '$notILike'].includes(searchOperator)) {
-          searchString = req.query[searchParam];
-        } else {
-          searchString = '%' + req.query[searchParam] + '%';
+        for (let str of req.query[searchParam]) {
+          var item = {};
+          var query = {};
+          var searchString;
+          if (![Sequelize.Op.like, '$like', '$ilike', '$iLike', '$notLike', '$notILike'].includes(searchOperator)) {
+            searchString = str;
+          } else {
+            searchString = '%' + str + '%';
+          }
+          query[searchOperator] = searchString;
+          item[attr] = query;
+          search.push(item);
         }
-        query[searchOperator] = searchString;
-        item[attr] = query;
-        search.push(item);
       });
 
       if (getKeys(criteria).length)

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -94,12 +94,14 @@ List.prototype.fetch = function(req, res, context) {
         for (let str of req.query[searchParam]) {
           var item = {};
           var query = {};
-          var searchString;
+          var searchString = str;
+          /*
           if (![Sequelize.Op.like, '$like', '$ilike', '$iLike', '$notLike', '$notILike'].includes(searchOperator)) {
             searchString = str;
           } else {
             searchString = '%' + str + '%';
           }
+          */
           query[searchOperator] = searchString;
           item[attr] = query;
           search.push(item);

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -93,7 +93,7 @@ List.prototype.fetch = function(req, res, context) {
         var item = {};
         var query = {};
         var searchString;
-        if (searchOperator !== Sequelize.Op.like) {
+        if (![Sequelize.Op.like, '$like', '$ilike', '$iLike', '$notLike', '$notILike'].includes(searchOperator)) {
           searchString = req.query[searchParam];
         } else {
           searchString = '%' + req.query[searchParam] + '%';
@@ -102,7 +102,7 @@ List.prototype.fetch = function(req, res, context) {
         item[attr] = query;
         search.push(item);
       });
-      
+
       if (getKeys(criteria).length)
         criteria = Sequelize.and(criteria, Sequelize.or.apply(null, search));
       else

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -107,9 +107,9 @@ List.prototype.fetch = function(req, res, context) {
       });
 
       if (getKeys(criteria).length)
-        criteria = Sequelize.and(criteria, Sequelize.and.apply(null, search));
+        criteria = Sequelize.and(criteria, Sequelize.or.apply(null, search));
       else
-        criteria = Sequelize.and.apply(null, search);
+        criteria = Sequelize.or.apply(null, search);
     }
   });
 

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -90,6 +90,7 @@ List.prototype.fetch = function(req, res, context) {
           }
         }
 
+        if (!Array.isArray(req.query[searchParam])) req.query[searchParam] = [req.query[searchParam]]
         for (let str of req.query[searchParam]) {
           var item = {};
           var query = {};

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -75,7 +75,7 @@ List.prototype.fetch = function(req, res, context) {
     var searchParam = searchData.param;
     if (_.has(req.query, searchParam)) {
       var search = [];
-      var searchOperator = searchData.operator || Sequelize.Op.like;
+      var searchOperator = searchData.operator || Sequelize.Op.iLike;
       var searchAttributes =
         searchData.attributes || getKeys(model.rawAttributes);
       searchAttributes.forEach(function(attr) {

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -106,9 +106,9 @@ List.prototype.fetch = function(req, res, context) {
       });
 
       if (getKeys(criteria).length)
-        criteria = Sequelize.and(criteria, Sequelize.or.apply(null, search));
+        criteria = Sequelize.and(criteria, Sequelize.and.apply(null, search));
       else
-        criteria = Sequelize.or.apply(null, search);
+        criteria = Sequelize.and.apply(null, search);
     }
   });
 


### PR DESCRIPTION
Using $ilike, $notlike, $notilike or even $like explicitly operators in search results in a search that does include the %% in the searchstring, making all of them only work if the string searched is an exact match.