### PR TITLE
Fix error on validation errors when using sequelize v5

### DIFF
--- a/lib/Controllers/base.js
+++ b/lib/Controllers/base.js
@@ -13,6 +13,7 @@ Controller.prototype.initialize = function(options) {
   options = options || {};
   this.endpoint = new Endpoint(options.endpoint);
   this.model = options.model;
+  this.sequelize = options.sequelize;
   this.app = options.app;
   this.resource = options.resource;
   this.include = options.include;
@@ -178,7 +179,7 @@ Controller.prototype._control = function(req, res, next) {
 
   hookChain
     .catch(errors.RequestCompleted, _.noop)
-    .catch(self.model.sequelize.ValidationError, function(err) {
+    .catch(self.sequelize.ValidationError, function(err) {
       var errorList = _.reduce(err.errors, function(result, error) {
         result.push({ field: error.path, message: error.message });
         return result;

--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -96,6 +96,7 @@ var Resource = function(options) {
       endpoint: endpoint,
       app: options.app,
       model: this.model,
+      sequelize: this.sequelize,
       include: this.include,
       resource: this
     });


### PR DESCRIPTION
A couple of small edits to make validation errors work with Sequelize 5. And if I read the docs correctly, this should work on sequelize 4 as well.