### PR TITLE
Fix delete endpoint for named restify

### DIFF
--- a/lib/Controllers/base.js
+++ b/lib/Controllers/base.js
@@ -71,7 +71,7 @@ Controller.prototype.route = function() {
       self = this;
 
   // NOTE: is there a better place to do this mapping?
-  if (app.name === 'restify' && self.method === 'delete')
+  if (self.method === 'delete' && !app[self.method])
     self.method = 'del';
 
   app[self.method](endpoint.string, function(req, res, next) {


### PR DESCRIPTION
according epilogue ol' #133 https://github.com/dchester/epilogue/issues/133 #144 #151 this should help if the endpoint should be restify's del() instead of express' delete()