### PR TITLE
Fix named associations endpoints

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -243,6 +243,7 @@ function autoAssociate(resource) {
         association.target.options.name.plural.toLowerCase();
       resource[subResourceName] = belongsToManyResource(Resource, resource, association);
     }
+    console.log("REsource.autoAsociate srn", subResourceName);
   });
 }
 

--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -68,7 +68,7 @@ var Resource = function(options) {
       this.attributes = getKeys(this.model.rawAttributes);
     }
   }
-  
+
   this.actions = options.actions;
   this.endpoints = {
     plural: options.endpoints[0],
@@ -227,21 +227,21 @@ function autoAssociate(resource) {
 
     var subResourceName;
     if (association.associationType === 'HasOne') {
-      subResourceName =
+      subResourceName = association.as ||
         association.target.options.name.singular.toLowerCase();
       resource[subResourceName] = hasOneResource(Resource, resource, association);
     } else if (association.associationType === 'HasMany') {
-      subResourceName =
+      subResourceName = association.as ||
         association.target.options.name.plural.toLowerCase();
       resource[subResourceName] = hasManyResource(Resource, resource, association);
     } else if (association.associationType === 'BelongsTo') {
-      subResourceName =
+      subResourceName = association.as ||
         association.target.options.name.singular.toLowerCase();
       resource[subResourceName] = belongsToResource(Resource, resource, association);
     } else if (association.associationType === 'BelongsToMany') {
-     subResourceName =
-       association.target.options.name.plural.toLowerCase();
-     resource[subResourceName] = belongsToManyResource(Resource, resource, association);
+      subResourceName = association.as ||
+        association.target.options.name.plural.toLowerCase();
+      resource[subResourceName] = belongsToManyResource(Resource, resource, association);
     }
   });
 }

--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -227,23 +227,23 @@ function autoAssociate(resource) {
 
     var subResourceName;
     if (association.associationType === 'HasOne') {
-      subResourceName = association.as ||
+      subResourceName = association.as ? association.as.toLowerCase() :
         association.target.options.name.singular.toLowerCase();
       resource[subResourceName] = hasOneResource(Resource, resource, association);
     } else if (association.associationType === 'HasMany') {
-      subResourceName = association.as ||
+      subResourceName = association.as ? association.as.toLowerCase() :
         association.target.options.name.plural.toLowerCase();
       resource[subResourceName] = hasManyResource(Resource, resource, association);
     } else if (association.associationType === 'BelongsTo') {
-      subResourceName = association.as ||
+      subResourceName = association.as ? association.as.toLowerCase() :
         association.target.options.name.singular.toLowerCase();
       resource[subResourceName] = belongsToResource(Resource, resource, association);
     } else if (association.associationType === 'BelongsToMany') {
-      subResourceName = association.as ||
+      subResourceName = association.as ? association.as.toLowerCase() :
         association.target.options.name.plural.toLowerCase();
       resource[subResourceName] = belongsToManyResource(Resource, resource, association);
     }
-    console.log("REsource.autoAsociate srn", subResourceName);
+    //console.log("REsource.autoAsociate srn", subResourceName);
   });
 }
 

--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -4,8 +4,8 @@ var _ = require('lodash');
 
 module.exports = function(Resource, resource, association) {
   // access points
-  var subResourceName =
-    association.target.options.name.plural.toLowerCase();
+  var subResourceName = association.as ||
+      association.target.options.name.plural.toLowerCase();
 
   // Find reverse association
   var associationPaired;

--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -4,7 +4,7 @@ var _ = require('lodash');
 
 module.exports = function(Resource, resource, association) {
   // access points
-  var subResourceName = association.as ||
+  var subResourceName = association.as ? association.as.toLowerCase() :
       association.target.options.name.plural.toLowerCase();
 
   // Find reverse association

--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -2,8 +2,8 @@
 
 module.exports = function(Resource, resource, association) {
   // access points
-  var subResourceName =
-    association.target.options.name.singular.toLowerCase();
+  var subResourceName = association.as ||
+      association.target.options.name.singular.toLowerCase();
 
   var associatedResource = new Resource({
     app: resource.app,

--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -2,7 +2,7 @@
 
 module.exports = function(Resource, resource, association) {
   // access points
-  var subResourceName = association.as ||
+  var subResourceName = association.as ? association.as.toLowerCase() :
       association.target.options.name.singular.toLowerCase();
 
   var associatedResource = new Resource({

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -2,8 +2,8 @@
 
 module.exports = function(Resource, resource, association) {
   // access points
-  var subResourceName =
-    association.target.options.name.plural.toLowerCase();
+  var subResourceName = association.as ||
+      association.target.options.name.plural.toLowerCase();
 
   var associatedResource = new Resource({
     app: resource.app,

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -2,7 +2,7 @@
 
 module.exports = function(Resource, resource, association) {
   // access points
-  var subResourceName = association.as ||
+  var subResourceName = association.as ? association.as.toLowerCase() :
       association.target.options.name.plural.toLowerCase();
 
   var associatedResource = new Resource({

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -2,8 +2,8 @@
 
 module.exports = function(Resource, resource, association) {
   // access points
-  var subResourceName =
-    association.target.options.name.singular.toLowerCase();
+  var subResourceName = association.as ||
+      association.target.options.name.singular.toLowerCase();
 
   var associatedResource = new Resource({
     app: resource.app,

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -2,7 +2,7 @@
 
 module.exports = function(Resource, resource, association) {
   // access points
-  var subResourceName = association.as ||
+  var subResourceName = association.as ? association.as.toLowerCase() :
       association.target.options.name.singular.toLowerCase();
 
   var associatedResource = new Resource({

--- a/tests/associations/sub-resource-name.test.js
+++ b/tests/associations/sub-resource-name.test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var expect = require('chai').expect,
+    rest = require('../../lib'),
+    test = require('../support');
+
+describe('Associations(named sub-resources)', function() {
+  describe('without using "as" to name an association', function() {
+    it('should name the sub-resources according to the model name', function(done) {
+      var Person = test.db.define('person', { name: { type: test.Sequelize.STRING } }, { underscored: true }),
+          Course = test.db.define('course', { name: { type: test.Sequelize.STRING } }, { underscored: true });
+      Course.hasMany(Person);
+      Course.hasOne(Person);
+      rest.initialize({
+        app: test.app,
+        sequelize: test.Sequelize
+      });
+      var resource = rest.resource({model: Course,
+                                    endpoints: ['/courses', '/courses/:id'],
+                                    associations: true});
+      expect(resource).to.not.have.property('students');
+      expect(resource).to.not.have.property('teacher');
+      expect(resource).to.have.property('people');
+      expect(resource).to.have.property('person');
+      done();
+    });
+  });
+  describe('using "as" to name an association', function() {
+    it('should name the sub-resources using the name provided by "as"', function(done) {
+      var Person = test.db.define('person', { name: { type: test.Sequelize.STRING } }, { underscored: true }),
+          Course = test.db.define('course', { name: { type: test.Sequelize.STRING } }, { underscored: true });
+      Course.hasMany(Person, { as: 'students' });
+      Course.hasOne(Person, { as: 'teacher' });
+      rest.initialize({
+        app: test.app,
+        sequelize: test.Sequelize
+      });
+      var resource = rest.resource({model: Course,
+                                    endpoints: ['/courses', '/courses/:id'],
+                                    associations: true});
+      expect(resource).to.have.property('students');
+      expect(resource).to.have.property('teacher');
+      expect(resource).to.not.have.property('people');
+      expect(resource).to.not.have.property('person');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
I checked [PR#28](https://github.com/tommybananas/finale/pull/28) which seems a working solution on express for issues like #18 , but fails on restify... it all falls on that, by default, express create case insensitive endpoints, but restify not.
 (like the test: if associated model is AdSlot, it will create endpoint `/api/channels/1/AdSlots` and it will fail the test which expected `/api/channels/1/adslots`. 

checking the `Resource.js` file,  finale (and epilogue I think) always uses the lowercase of the target model  (even if the model was on CamelCase), and I suggest keeping that idea with this fix... 

I'm not sure if a better solution should be to make restify endpoints case insensitive (on express there's a default flag for that, on restify I think it's regexp magic) but it's open to discussion...