### PR TITLE
Enable search parameters to specify values on included models

### DIFF
--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -158,7 +158,7 @@ List.prototype.fetch = function(req, res, context) {
     while (path.length > 1) {
       const alias = path.shift();
       const prop = path[0];
-      let include = includes.find(i => i === alias || i.as === alias);
+      let include = includes.find(i => i === alias || i.as === alias); // jshint ignore:line
       if (typeof include === "string") {
         // replace simple include definition with model-as syntax
         const association = currentModel.associations[alias];

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -157,7 +157,7 @@ List.prototype.fetch = function(req, res, context) {
     let currentModel = model;
     while (path.length > 1) {
       const alias = path.shift();
-      const [prop] = path;
+      const prop = path[0];
       let include = includes.find(i => i === alias || i.as === alias);
       if (typeof include === "string") {
         // replace simple include definition with model-as syntax

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -154,15 +154,26 @@ List.prototype.fetch = function(req, res, context) {
   getKeys(req.query).forEach(key => {
     const path = key.split(".");
     let includes = options.include;
+    let currentModel = model;
     while (path.length > 1) {
       const alias = path.shift();
       const [prop] = path;
-      const include = includes.find(i => i.as === alias);
+      let include = includes.find(i => i === alias || i.as === alias);
+      if (typeof include === "string") {
+        // replace simple include definition with model-as syntax
+        const association = currentModel.associations[alias];
+        include = {
+          model: association.target,
+          as: association.options.as
+        };
+        includes.splice(includes.indexOf(alias), 1, include);
+      }
       if (
         !include || 
         (path.length > 1 && !include.include) ||
         (path.length === 1 && !include.model && !_.has(include.model.rawAttributes, prop))
       ) return;
+      currentModel = include.model;
       includes = include.include;
       if (path.length === 1) {        
         include.where = { [prop]: req.query[key] };

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -40,7 +40,12 @@ List.prototype.fetch = function(req, res, context) {
       model = this.model,
       options = context.options || {},
       criteria = context.criteria || {},
-      include = this.include,
+      // clone the resource's default includes so we can modify them only for this request
+      include = _.cloneDeepWith(this.include, value => {
+        // ...but don't clone Sequelize models
+        if (value.prototype && value.prototype.toString.includes('SequelizeInstance:'))
+          return value;
+      }),
       includeAttributes = this.includeAttributes,
       Sequelize = this.resource.sequelize,
       defaultCount = 100,
@@ -144,6 +149,26 @@ List.prototype.fetch = function(req, res, context) {
 
   if (getKeys(extraSearchCriteria).length)
     criteria = _.assign(criteria, extraSearchCriteria);
+  
+  // look for search parameters that reference properties on included models
+  getKeys(req.query).forEach(key => {
+    const path = key.split(".");
+    let includes = options.include;
+    while (path.length > 1) {
+      const alias = path.shift();
+      const [prop] = path;
+      const include = includes.find(i => i.as === alias);
+      if (
+        !include || 
+        (path.length > 1 && !include.include) ||
+        (path.length === 1 && !include.model && !_.has(include.model.rawAttributes, prop))
+      ) return;
+      includes = include.include;
+      if (path.length === 1) {        
+        include.where = { [prop]: req.query[key] };
+      }
+    }
+  });
 
   // do the actual lookup
   if (getKeys(criteria).length)

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -43,7 +43,7 @@ List.prototype.fetch = function(req, res, context) {
       // clone the resource's default includes so we can modify them only for this request
       include = _.cloneDeepWith(this.include, value => {
         // ...but don't clone Sequelize models
-        if (value.prototype && value.prototype.toString.includes('SequelizeInstance:'))
+        if (value.prototype && value.prototype.toString().includes('SequelizeInstance:'))
           return value;
       }),
       includeAttributes = this.includeAttributes,


### PR DESCRIPTION
If a Resource is defined to include associated models by default, or includes are added to context in Milestones ~~, using the verbose `include: [ { model: ..., as: '...' } ]` syntax~~, this PR enables search parameters to target properties on included models.

e.g. If you have

```js
finale.resource({
  model: User,
  endpoints: [`/users`, `/users/:id`],    
  actions: ["read", "update", "list"],
  include: [
    "contacts",
    { 
      model: UserProfile,
      as: "profile",
      include: [
        {
          model: UserProfileImage,
          as: "image"
        }    
      ]
    }
  ]
});
```

then you can do something like this: 
`GET /admin/users?contacts.type=family`
or
`GET /admin/users?profile.image.type=jpg`