### PR TITLE
Wrap iLike operator with % characters

### DIFF
--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -126,10 +126,10 @@ List.prototype.fetch = function(req, res, context) {
         var item = {};
         var query = {};
         var searchString;
-        if (searchOperator !== Sequelize.Op.like) {
-          searchString = req.query[searchParam];
-        } else {
+        if (searchOperator === Sequelize.Op.like || searchOperator === Sequelize.Op.iLike) {
           searchString = '%' + req.query[searchParam] + '%';
+        } else {
+          searchString = req.query[searchParam];
         }
         if(searchOverride === "STARTS_WITH"){
           searchString = req.query[searchParam] + '%';


### PR DESCRIPTION
Using the $ilike operator does not include the %% in the searchString, making it only work if the string searched is an exact match.