### PR TITLE
Sort search and group for fields on included models

### DIFF
--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -112,7 +112,7 @@ List.prototype.fetch = function(req, res, context) {
       var searchAttributes =
         searchData.attributes || getKeys(model.rawAttributes);
       searchAttributes.forEach(function(attr) {
-        if(stringOperators.indexOf(searchOperator) !== -1){
+        if(stringOperators.indexOf(searchOperator) !== -1 && attr.indexOf('.') === -1){
           var attrType = model.rawAttributes[attr].type;
           if (!(attrType instanceof Sequelize.STRING) &&
               !(attrType instanceof Sequelize.TEXT)) {
@@ -135,8 +135,6 @@ List.prototype.fetch = function(req, res, context) {
           searchString = req.query[searchParam] + '%';
           searchOperator = Sequelize.Op.like;
         }
-        
-
         query[searchOperator] = searchString;
         item[attr] = query;
         search.push(item);

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -171,6 +171,9 @@ List.prototype.fetch = function(req, res, context) {
       //    ['primaryField', 'asc'],
       // ]
       //
+      // This also may require "context.options = {subQuery: false}" if you use a
+      // belongsToMany association
+      //
       // but as a quick solution we can use a Sequelize.literal
       var lookupName = actualName.indexOf('.') > -1 ? Sequelize.literal(actualName) : actualName;
       order.push([lookupName, direction]);

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -140,7 +140,6 @@ List.prototype.fetch = function(req, res, context) {
         query[searchOperator] = searchString;
         item[attr] = query;
         search.push(item);
-        console.log("just pushed search item: ", item);
       });
       
       if (getKeys(criteria).length)
@@ -242,6 +241,38 @@ List.prototype.fetch = function(req, res, context) {
     options.distinct = true;
   }
  
+  // the result from findAndCountAll using options.group has contains an array for result.count
+  // If we are grouping handle this in two queries.
+  if(options.group){
+    return model
+      .findAll(options)
+      .then(function(result) {
+        context.instance = result;
+        var start = offset;
+        var end = start + result.length - 1;
+        end = end === -1 ? 0 : end;
+
+        if (self.resource.associationOptions.removeForeignKeys) {
+          _.each(context.instance, function(instance) {
+            _.each(includeAttributes, function(attr) {
+              delete instance[attr];
+              delete instance.dataValues[attr];
+            });
+          });
+        }
+
+        return model
+          .count({where: options.where})
+          .then(function(result) {
+            if (!!self.resource.pagination){
+              res.header('Content-Range', 'items ' + [[start, end].join('-'), result].join('/'));
+            }
+            return context.continue;
+          });
+      });
+  }
+  
+  
   return model
     .findAndCountAll(options)
     .then(function(result) {

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -157,14 +157,23 @@ List.prototype.fetch = function(req, res, context) {
     var sortQuery = req.query[sortParam] || this.resource.sort.default || '';
     var sortColumns = sortQuery.split(',');
     sortColumns.forEach(function(sortColumn) {
-      if (sortColumn.indexOf('-') === 0) {
-        var actualName = sortColumn.substring(1);
-        order.push([actualName, 'DESC']);
-        columnNames.push(actualName);
-      } else {
-        columnNames.push(sortColumn);
-        order.push([sortColumn, 'ASC']);
-      }
+      var desc = sortColumn.indexOf('-') === 0;
+      var direction = desc ? 'DESC' : 'ASC';
+      var actualName = desc ? sortColumn.substring(1) : sortColumn;
+      columnNames.push(actualName);
+
+      // If the column lookup has a '.' then assume we're sorting by an included associated model.
+      // 
+      // It would be better to search the resource.include and find the correct
+      // sequelize model class to use the recommended format e.g.
+      // order: [
+      //    [{ model: models.NestedModel, as: 'NestedModel' }, 'nestedField', 'asc'],
+      //    ['primaryField', 'asc'],
+      // ]
+      //
+      // but as a quick solution we can use a Sequelize.literal
+      var lookupName = actualName.indexOf('.') > -1 ? Sequelize.literal(actualName) : actualName;
+      order.push([lookupName, direction]);
     });
     var allowedColumns = this.resource.sort.attributes || getKeys(model.rawAttributes);
     var disallowedColumns = _.difference(columnNames, allowedColumns);

--- a/tests/resource/pagination.test.js
+++ b/tests/resource/pagination.test.js
@@ -87,7 +87,7 @@ describe('Resource(pagination)', function() {
   });
 });
 
-describe('Resource(pagination with associated models and grouping)', function() {
+describe('Resource(pagination with included models and grouping)', function() {
   before(function() {
     test.models.User = test.db.define('users', {
       id: { type: test.Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
@@ -247,7 +247,7 @@ describe('Resource(pagination with associated models and grouping)', function() 
     });
   });
 
-  it.only('should allow grouping associated records while maintaining pagination', function(done) {
+  it('should allow grouping associated records while maintaining pagination', function(done) {
     request.get({ url: test.baseUrl + '/users' }, function(err, response, body) {
       expect(response.statusCode).to.equal(200);
       expect(response.headers['content-range']).to.equal('items 0-4/5');

--- a/tests/resource/pagination.test.js
+++ b/tests/resource/pagination.test.js
@@ -85,5 +85,158 @@ describe('Resource(pagination)', function() {
     });
 
   });
+});
 
+describe('Resource(pagination with associated models)', function() {
+  before(function() {
+    test.models.User = test.db.define('users', {
+      id: { type: test.Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+      username: {
+        type: test.Sequelize.STRING,
+        allowNull: false
+      },
+      email: {
+        type: test.Sequelize.STRING,
+        unique: { msg: 'must be unique' },
+        validate: { isEmail: true }
+      }
+    }, {
+      underscored: true,
+      timestamps: false
+    });
+
+    test.models.Hobby = test.db.define('hobby', {
+      id: { type: test.Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+      name: { type: test.Sequelize.STRING }
+    }, {
+      underscored: true,
+      timestamps: false
+    });
+
+    test.models.Profile = test.db.define('profile', {
+      id: { type: test.Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+      nickname: { type: test.Sequelize.STRING }
+    }, {
+      underscored: true,
+      timestamps: false
+    });
+
+    test.models.User.hasOne(test.models.Profile, {
+      as: 'profile',
+    });
+    test.models.User.belongsToMany(test.models.Hobby, {
+      as: 'hobbies',
+      through: 'user_hobbies',
+      timestamps: false
+    });
+    test.models.Hobby.belongsToMany(test.models.User, {
+      as: 'users',
+      through: 'user_hobbies',
+      timestamps: false
+    });
+
+    return Promise.all([ test.initializeDatabase(), test.initializeServer() ])
+      .then(function() {
+        rest.initialize({ app: test.app, sequelize: test.Sequelize });
+        const userResource = rest.resource({
+          model: test.models.User,
+          endpoints: ['/users', '/users/:id'],
+          include: [
+            {
+              model: test.models.Hobby,
+              as: 'hobbies',
+            },
+            {
+              model: test.models.Profile,
+              attributes: ['nickname'],
+              as: 'profile',
+            },
+          ],
+          sort: {
+            attributes: ['profile.nickname', 'username'],
+          }
+        });
+
+        userResource.list.fetch.before(function(req, res, context) {
+          context.options = {
+            subQuery: false
+          };
+          return context.continue;
+        });
+
+        test.userlist = [
+          { username: 'arthur', email: 'arthur@gmail.com' },
+          { username: 'james', email: 'james@gmail.com' },
+          { username: 'henry', email: 'henry@gmail.com' },
+          { username: 'william', email: 'william@gmail.com' },
+          { username: 'edward', email: 'edward@gmail.com' }
+        ];
+
+        test.hobbylist = [
+          { name: 'reading' },
+          { name: 'bowling' },
+          { name: 'running' },
+          { name: 'swimming' },
+          { name: 'coding' }
+        ];
+        
+        test.profilelist = [
+          { nickname: 'X' },
+          { nickname: 'Z' },
+          { nickname: 'C' },
+          { nickname: 'B' },
+          { nickname: 'A' }
+        ];
+
+        return Promise.all([
+          test.models.User.bulkCreate(test.userlist),
+          test.models.Hobby.bulkCreate(test.hobbylist),
+          test.models.Profile.bulkCreate(test.profilelist)
+        ]).then(function(){
+          return Promise.all([
+            test.models.User.findAll(),
+            test.models.Hobby.findAll(),
+            test.models.Profile.findAll()
+          ]).then(function(results){
+            const users = results[0];
+            const hobbies = results[1];
+            const profiles = results[2];
+            return Promise.all(
+              users.map((u, i) => u.setProfile(profiles[i]))
+            ).then(function(){
+              return Promise.all(
+                users.map((u, i) => u.setHobbies(hobbies))
+              );
+            });
+          });
+        });
+
+      });
+  });
+
+  after(function() {
+    return test.clearDatabase()
+      .then(function() { test.closeServer(); });
+  });
+
+  it('should list records with associated models', function(done) {
+    request.get({ url: test.baseUrl + '/users' }, function(err, response, body) {
+      expect(response.statusCode).to.equal(200);
+      var records = JSON.parse(body).map(function(r) { delete r.id; return r; });
+      records.forEach(r => {
+        expect(r.profile.nickname).to.be.a('string');
+      });
+      expect(response.headers['content-range']).to.equal('items 0-4/5');
+      done();
+    });
+  });
+
+  it('should list the correct number of records when sorting by a nested field', function(done) {
+    request.get({ url: test.baseUrl + '/users?sort=profile.nickname' }, function(err, response, body) {
+      expect(response.statusCode).to.equal(200);
+      //var records = JSON.parse(body).map(function(r) { delete r.id; return r; });
+      expect(response.headers['content-range']).to.equal('items 0-4/5');
+      done();
+    });
+  });
 });

--- a/tests/resource/sort.test.js
+++ b/tests/resource/sort.test.js
@@ -190,3 +190,103 @@ describe('Resource(sort)', function() {
     });
   });
 });
+
+describe('Resource(sort on included models)', function() {
+  before(function() {
+    test.models.User = test.db.define('users', {
+      id: { type: test.Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+      username: {
+        type: test.Sequelize.STRING,
+        allowNull: false
+      },
+      email: {
+        type: test.Sequelize.STRING,
+        unique: { msg: 'must be unique' },
+        validate: { isEmail: true }
+      }
+    }, {
+      underscored: true,
+      timestamps: false
+    });
+    test.models.Profile = test.db.define('profile', {
+      id: { type: test.Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+      nickname: { type: test.Sequelize.STRING }
+    }, {
+      underscored: true,
+      timestamps: false
+    });
+    test.models.User.hasOne(test.models.Profile, {
+      as: 'profile',
+    });
+
+    test.userlist = [
+      { username: 'arthur', email: 'arthur@gmail.com' },
+      { username: 'james', email: 'james@gmail.com' },
+      { username: 'henry', email: 'henry@gmail.com' },
+      { username: 'william', email: 'william@gmail.com' },
+      { username: 'edward', email: 'edward@gmail.com' }
+    ];
+    
+    test.profilelist = [
+      { nickname: 'X' },
+      { nickname: 'Z' },
+      { nickname: 'C' },
+      { nickname: 'B' },
+      { nickname: 'A' }
+    ];
+    
+  });
+
+  beforeEach(function() {
+    return Promise.all([ test.initializeDatabase(), test.initializeServer() ])
+      .then(function() {
+
+        rest.initialize({ app: test.app, sequelize: test.Sequelize });
+        test.userResource = rest.resource({
+          model: test.models.User,
+          endpoints: ['/users', '/users/:id'],
+          include: [
+            {
+              model: test.models.Profile,
+              attributes: ['nickname'],
+              as: 'profile',
+            },
+          ],
+          sort: {
+            attributes: ['profile.nickname', 'username'],
+            default: 'username'
+          }
+        });
+
+        return Promise.all([
+          test.models.User.bulkCreate(test.userlist),
+          test.models.Profile.bulkCreate(test.profilelist)
+        ]).then(function(){
+          return Promise.all([
+            test.models.User.findAll(),
+            test.models.Profile.findAll()
+          ]).then(function(results){
+            const users = results[0];
+            const profiles = results[1];
+            return Promise.all(users.map((u, i) => u.setProfile(profiles[i])));
+          });
+        });
+      });
+  });
+
+  afterEach(function() {
+    return test.clearDatabase()
+      .then(function() { return test.closeServer(); });
+  });
+
+  it('should allow sorting by an included model field', function(done) {
+    request.get({ url: test.baseUrl + '/users?sort=profile.nickname' }, function(err, response, body) {
+      expect(response.statusCode).to.equal(200);
+      var records = JSON.parse(body).map(function(r) { delete r.id; return r; });
+      expect(records[0].profile.nickname).to.equal('A');
+      expect(records[4].profile.nickname).to.equal('Z');
+      done();
+    });
+  });
+  
+});


### PR DESCRIPTION
This fixes 3 Issues for `list.js` I've run into while dealing with included/associated models in a resource. I've tried to isolate these 3 problems in tests but the behavior changes based on if the resource has `options.subQuery = true/false` set and if the associations between models are one-to-many or many-to-many. Ideally I'm looking to be able to sort, search, and group by fields on included models at the same time.

## 1. Group By breaks pagination
### Current Version
If you use a group command (my test example is `context.options.group = ['users.id']`) then the sequelize `findAndCountAll()` method returns a list of grouped counts instead of one count number.
### Change
If `options.group` is set then split the `find` and `count` into two queries.

## 2. Sort by field on associated model
### Current Version
Sorting by a field on an included model doesn't work. Sequelize uses the wrong table name for the nested field when generating SQL

### Change
I use a Sequelize.literal() in the sort if the field path has a period in it.


## 3. Search with "LIKE" on a associated resource
### Current Version
If you want to search for a field on an associated resource you have the following options
1. Use the name of the field as the url param. My example is `?profile.nickname=name`
2. Specify a search object on the resource definition to choose your own param name. If you choose this method you need to use the `Sequelize.Op.eq` operator, otherwise the search is picked up as a `stringOperator` in `list.js:115` and throws an error because the path to the included model isn't a sequelize.STRING

### Change
I exclude search keys with a period in the serach for stringOperators to allow using `Sequelize.Op.like` in the search definition in the resource

**Note**: the field name in the search definition still requires the dollars around the field e.g. `$profile.nickname$`
