### PR TITLE
Allow options to be passed to all Controllers

### DIFF
--- a/lib/Controllers/create.js
+++ b/lib/Controllers/create.js
@@ -15,6 +15,8 @@ Create.prototype.method = 'post';
 Create.prototype.plurality = 'plural';
 
 Create.prototype.write = function(req, res, context) {
+  var options = context.options || {};
+  
   context.attributes = _.defaults(context.attributes, req.body);
   var self = this;
 
@@ -29,7 +31,7 @@ Create.prototype.write = function(req, res, context) {
         var attr = context.attributes[association.as];
 
         if(attr) {
-          //add the add_to_children attributes to the attr 
+          //add the add_to_children attributes to the attr
           if(_.isArray(attr)){
             //if array, add the add_to_children to each object
             for(var x=0;x<attr.length;x++) {
@@ -50,16 +52,14 @@ Create.prototype.write = function(req, res, context) {
     });
   }
 
-var creation_include = _.assign([],this.include);
+options[include] = _.assign([],this.include);
 
 if(context.shallow) {
-    creation_include = [];
+    options[include] = [];
   }
 
   return this.model
-    .create(context.attributes, {
-      include: creation_include
-    })
+    .create(context.attributes, options)
     .then(function(instance) {
       if (self.resource) {
         var endpoint = self.resource.endpoints.singular;
@@ -78,7 +78,7 @@ if(context.shallow) {
           reloadOptions.attributes = { exclude: self.resource.excludeAttributes };
 
         if(context.shallow)
-          delete reloadOptions.include;  
+          delete reloadOptions.include;
         return instance.reload(reloadOptions);
       }
 

--- a/lib/Controllers/delete.js
+++ b/lib/Controllers/delete.js
@@ -17,8 +17,10 @@ Delete.prototype.plurality = 'singular';
 Delete.prototype.fetch = ReadController.prototype.fetch;
 
 Delete.prototype.write = function(req, res, context) {
+  var options = context.options || {};
+
   return context.instance
-    .destroy()
+    .destroy(options)
     .then(function() {
       context.instance = {};
       return context.continue;

--- a/lib/Controllers/update.js
+++ b/lib/Controllers/update.js
@@ -21,7 +21,9 @@ Update.prototype.plurality = 'singular';
 Update.prototype.fetch = ReadController.prototype.fetch;
 
 Update.prototype.write = function(req, res, context) {
-  var instance = context.instance;
+  var instance = context.instance,
+      options = context.options || {};
+
   context.attributes = _.defaults(context.attributes, req.body);
 
   this.endpoint.attributes.forEach(function(a) {
@@ -42,7 +44,7 @@ Update.prototype.write = function(req, res, context) {
         var attr = context.attributes[association.as];
 
         if(attr) {
-           //add the add_to_children attributes to the attr 
+           //add the add_to_children attributes to the attr
            if(_.isArray(attr)){
             //if array, add the add_to_children to each object
             for(var x=0;x<attr.length;x++) {
@@ -73,25 +75,25 @@ Update.prototype.write = function(req, res, context) {
     });
 
   return instance
-    .save()
+    .save(options)
     .then(function(instance) {
       if (reloadAfter) {
         var reloadOptions = {};
         if (Array.isArray(self.include) && self.include.length)
           reloadOptions.include=self.include;
         if (!!self.resource.excludeAttributes)
-          reloadOptions.attributes = {exclude: self.resource.excludeAttributes };   
+          reloadOptions.attributes = {exclude: self.resource.excludeAttributes };
         if(context.shallow) {
           console.log("DELETING RELOAD OPTIONS in UPDATE DUE TO SHALLOW false.");
           console.log("RELOAD OPTIONS in UPDATE right before we delete the includes due to shallow being false",reloadOptions);
 
-          delete reloadOptions.include;            
+          delete reloadOptions.include;
         }
         return instance.reload(reloadOptions);
       } else {
         return instance;
       }
-    }).then(function (instance) { 
+    }).then(function (instance) {
       if (!!self.resource.excludeAttributes) {
         self.resource.excludeAttributes.forEach(function(attr) {
           delete instance.dataValues[attr];


### PR DESCRIPTION
Enables the passing of options to the static sequelize methods `create()`, `save()`, and `destroy()` used in the Controller files create.js, update.js, and delete.js, respectively.

I am submitting this update because I need this functionality in order to enable user tracking in the [sequelize-paper-trail](https://github.com/nielsgl/sequelize-paper-trail) library.  I need to be able to pass a `userId` property through the `options` object that gets passed to the methods I mentioned earlier.

The passing of the `options` object was already set up for the other Controller files: read.js & list.js.   This enables the same functionality for the other Controllers.